### PR TITLE
wagtail url routes for pages by id and slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 Main project for http://bash-shell.net/
 
 
+### Test Fixtures
+
+```
+# For blog page tests
+python manage.py dumpdata --natural-foreign --indent=2 -e blog.post -e blog.tag accounts sites wagtailcore.site wagtailcore.page wagtailcore.pagerevision
+
+# May need to add wagtailcore.workflowpage, wagtailcore.workflowtask, wagtailcore.task, wagtailcore.workflow, wagtailcore.groupapprovaltask
+```
+
 # Tools
 
 ## Frameworks

--- a/bash_shell_net/sitemaps.py
+++ b/bash_shell_net/sitemaps.py
@@ -22,11 +22,13 @@ class BlogSitemap(WagtailSitemap):
     def lastmod(self, obj):
         return obj.last_published_at
 
+    def location(self, obj):
+        return obj.get_id_and_slug_url()
+
 
 class OnTapSitemap(WagtailSitemap):
     """
     Sitemap for posts
-    main_298a6006830dacabb4569bb44b23e66b2a7b1150
     """
 
     # changefreq = "never"
@@ -43,8 +45,7 @@ class OnTapSitemap(WagtailSitemap):
 
 class RecipePageSitemap(WagtailSitemap):
     """
-    Sitemap for posts
-    main_298a6006830dacabb4569bb44b23e66b2a7b1150
+    Sitemap for on_tap.RecipePage
     """
 
     # changefreq = "never"
@@ -61,8 +62,7 @@ class RecipePageSitemap(WagtailSitemap):
 
 class BatchLogPageSitemap(WagtailSitemap):
     """
-    Sitemap for posts
-    main_298a6006830dacabb4569bb44b23e66b2a7b1150
+    Sitemap for on_tap.BatchLogPage
     """
 
     # changefreq = "never"

--- a/bash_shell_net/templates/on_tap/batch_log.html
+++ b/bash_shell_net/templates/on_tap/batch_log.html
@@ -41,7 +41,7 @@
               <li>Brewed: {{ page.brewed_date|default:"N/A" }}</li>
               <li>Packaged: {{ page.packaged_date|default:"N/A" }}</li>
               <li>On Tap: {{ page.on_tap_date|default:"N/A" }}</li>
-              <li>Recipe: <a href="{% pageurl page.recipe_page %}">{{ page.recipe_page.name }}</a></li>
+              <li>Recipe: <a href="{{ page.recipe_page.id_and_slug_url }}">{{ page.recipe_page.name }}</a></li>
             </ul>
           </div>
         </div>

--- a/bash_shell_net/templates/on_tap/on_tap.html
+++ b/bash_shell_net/templates/on_tap/on_tap.html
@@ -17,7 +17,7 @@
       <div class="col-md-4 col-12 mt-3 mt-md-0 pr-0">
         <div class="card" style="min-height: 275px">
           <div class="card-header text-center">
-            <div class="w-100"><a href="{% pageurl batch.recipe_page %}">{{ batch.recipe_page.name }}</a></div>
+            <div class="w-100"><a href="{{ batch.recipe_page.id_and_slug_url }}">{{ batch.recipe_page.name }}</a></div>
             <small>{{ batch.recipe_page.style.name }}{% if batch.recipe_page.style.bjcp_category %} ({{ batch.recipe_page.style.bjcp_category }}){% endif %}</small>
           </div>
           <div class="card-body">
@@ -26,7 +26,7 @@
             <!-- <a href="{% pageurl batch.recipe_page %}" class="btn btn-primary">recipe</a> -->
           </div>
           <div class="card-footer">
-            <a href="{% pageurl batch %}" class="card-link">Details</a>
+            <a href="{{ batch.id_and_slug_url }}" class="card-link">Details</a>
           </div>
         </div>
       </div>
@@ -57,8 +57,8 @@
           {% for batch in upcoming_batches %}
             <tr>
               <td>
-                <a href="{% pageurl batch.recipe_page %}">{{ batch.recipe_page.name }}</a>
-                {% if batch.status != 'planned' %} (<a href="{% pageurl batch %}">Log</a>){% endif %}
+                <a href="{{ batch.recipe_page.id_and_slug_url }}">{{ batch.recipe_page.name }}</a>
+                {% if batch.status != 'planned' %} (<a href="{{ batch.id_and_slug_url }}">Log</a>){% endif %}
               </td>
               <td>{{ batch.recipe_page.style }}</td>
               <td>{{ batch.get_status_display }}</td>
@@ -84,7 +84,7 @@
       <tbody>
         {% for batch in past_batches %}
           <tr>
-            <td><a href="{% pageurl batch.recipe_page %}">{{ batch.recipe_page.name }}</a> (<a href="{% pageurl batch %}">Log</a>)</td><td>{{ batch.recipe_page.style }}</td><td>{{ batch.get_status_display }}</td><td>{{ batch.brewed_date }}</td><td>{{ batch.packaged_date|default:"" }}</td><td>{{ batch.on_tap_date|default:"" }}</td>
+            <td><a href="{{ batch.recipe_page.id_and_slug_url }}">{{ batch.recipe_page.name }}</a> (<a href="{{ batch.id_and_slug_url }}">Log</a>)</td><td>{{ batch.recipe_page.style }}</td><td>{{ batch.get_status_display }}</td><td>{{ batch.brewed_date }}</td><td>{{ batch.packaged_date|default:"" }}</td><td>{{ batch.on_tap_date|default:"" }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/bash_shell_net/templates/wagtail_templates/blog/post_detail.html
+++ b/bash_shell_net/templates/wagtail_templates/blog/post_detail.html
@@ -11,9 +11,9 @@
   <div class="page-header col-12">
      <h2>{{ page.title }}</h2>
      {% comment %}
-     rather than page.owner, may want to make a field specifically for authors.
-     See https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/blog/models.py#L23 and how
-     it is used on https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/blog/models.py#L85
+       rather than page.owner, may want to make a field specifically for authors.
+       See https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/blog/models.py#L23 and how
+       it is used on https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/blog/models.py#L85
      {% endcomment %}
       <em>by {% if page.owner %}{{ page.owner.get_full_name }}{% elif user.is_authenticated %}{{ user.get_full_name }}{% endif %} on {{ page.last_published_at|date:"N j, Y, P T"|default:"Not Published" }}</em>
   </div>
@@ -22,7 +22,7 @@
     {% include_block page.body %}
   </div>
   <nav class="blog-pagination">
-    <a class="btn btn-outline-primary {% if not next_post %}disabled{% endif %}" href="{% if next_post %}{% pageurl next_post %}{% else %}#{% endif %}">Newer</a>
-    <a class="btn btn-outline-primary {% if not previous_post %}disabled{% endif %}" href="{% if previous_post %}{% pageurl previous_post %}{% else %}#{% endif %}">Older</a>
+    <a class="btn btn-outline-primary {% if not next_post %}disabled{% endif %}" href="{% if next_post %}{{ next_post.id_and_slug_url }}{% else %}#{% endif %}">Newer</a>
+    <a class="btn btn-outline-primary {% if not previous_post %}disabled{% endif %}" href="{% if previous_post %}{{ previous_post.id_and_slug_url }}{% else %}#{% endif %}">Older</a>
   </nav>
 {% endblock %}

--- a/bash_shell_net/templates/wagtail_templates/blog/post_index.html
+++ b/bash_shell_net/templates/wagtail_templates/blog/post_index.html
@@ -14,7 +14,7 @@
       {# markdown will properly wrap the following text in appropriate tags if needed #}
       {# how to us include_block here with the truncatewords_html? #}
       {{ post.body|truncatewords_html:"100"|safe }}
-      <span><a href="{% pageurl post %}">&rarr; read more</a></span>
+      <span><a href="{{ post.id_and_slug_url }}">&rarr; read more</a></span>
     </div>
   {% endfor %}
 

--- a/blog/fixtures/test_pages.json
+++ b/blog/fixtures/test_pages.json
@@ -1,0 +1,227 @@
+[
+{
+  "model": "accounts.user",
+  "pk": 1,
+  "fields": {
+    "password": "pbkdf2_sha256$216000$J3agj7Nl5Dhq$zc9WD8urEwUbWyYQbkXrWksPUjQXolNrgKZl+omtCRI=",
+    "last_login": "2020-12-30T03:02:53.721Z",
+    "is_superuser": true,
+    "email": "user@example.com",
+    "first_name": "Dev",
+    "last_name": "McDevpants",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2017-11-03T01:19:11.178Z",
+    "username": "user@example.com",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "sites.site",
+  "pk": 1,
+  "fields": {
+    "domain": "example.com",
+    "name": "example.com"
+  }
+},
+{
+  "model": "wagtailcore.site",
+  "pk": 1,
+  "fields": {
+    "hostname": "localhost",
+    "port": 80,
+    "site_name": "",
+    "root_page": 2,
+    "is_default_site": true
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 1,
+  "fields": {
+    "path": "0001",
+    "depth": 1,
+    "numchild": 1,
+    "translation_key": "74b7e641-fc6a-4d47-8c00-770af905b4fd",
+    "locale": 1,
+    "title": "Root",
+    "draft_title": "Root",
+    "slug": "root",
+    "content_type": [
+      "wagtailcore",
+      "page"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/",
+    "owner": null,
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "locked_at": null,
+    "locked_by": null,
+    "first_published_at": null,
+    "last_published_at": null,
+    "latest_revision_created_at": null,
+    "live_revision": null,
+    "alias_of": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 2,
+  "fields": {
+    "path": "00010001",
+    "depth": 2,
+    "numchild": 1,
+    "translation_key": "d53a1c1e-9a63-41e8-9d6c-8a29abad6c4f",
+    "locale": 1,
+    "title": "Welcome to your new Wagtail site!",
+    "draft_title": "Welcome to your new Wagtail site!",
+    "slug": "home",
+    "content_type": [
+      "wagtailcore",
+      "page"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/",
+    "owner": null,
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "locked_at": null,
+    "locked_by": null,
+    "first_published_at": null,
+    "last_published_at": null,
+    "latest_revision_created_at": null,
+    "live_revision": null,
+    "alias_of": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 3,
+  "fields": {
+    "path": "000100010001",
+    "depth": 3,
+    "numchild": 1,
+    "translation_key": "0bf37d4c-9946-4bbd-b086-d2a6ac15916b",
+    "locale": 1,
+    "title": "Blog Index",
+    "draft_title": "Blog Index",
+    "slug": "blog-index",
+    "content_type": [
+      "blog",
+      "blogpageindex"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/blog-index/",
+    "owner": [
+      "user@example.com"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "locked_at": null,
+    "locked_by": null,
+    "first_published_at": "2020-12-30T03:03:56.570Z",
+    "last_published_at": "2020-12-30T03:03:56.570Z",
+    "latest_revision_created_at": "2020-12-30T03:03:56.555Z",
+    "live_revision": 1,
+    "alias_of": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 4,
+  "fields": {
+    "path": "0001000100010001",
+    "depth": 4,
+    "numchild": 0,
+    "translation_key": "8acc22fa-a77a-4a45-b1df-781b2306ad8a",
+    "locale": 1,
+    "title": "First Post",
+    "draft_title": "First Post",
+    "slug": "first-post",
+    "content_type": [
+      "blog",
+      "blogpage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/blog-index/first-post/",
+    "owner": [
+      "user@example.com"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "locked_at": null,
+    "locked_by": null,
+    "first_published_at": "2020-12-30T03:05:10.091Z",
+    "last_published_at": "2020-12-30T03:05:10.091Z",
+    "latest_revision_created_at": "2020-12-30T03:05:10.077Z",
+    "live_revision": 2,
+    "alias_of": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 1,
+  "fields": {
+    "page": 3,
+    "submitted_for_moderation": false,
+    "created_at": "2020-12-30T03:03:56.555Z",
+    "user": [
+      "user@example.com"
+    ],
+    "content_json": "{\"pk\": 3, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"translation_key\": \"0bf37d4c-9946-4bbd-b086-d2a6ac15916b\", \"locale\": 1, \"title\": \"Blog Index\", \"draft_title\": \"Blog Index\", \"slug\": \"blog-index\", \"content_type\": 42, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/blog-index/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"locked_at\": null, \"locked_by\": null, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"alias_of\": null}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 2,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2020-12-30T03:05:10.077Z",
+    "user": [
+      "user@example.com"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"0001000100010001\", \"depth\": 4, \"numchild\": 0, \"translation_key\": \"8acc22fa-a77a-4a45-b1df-781b2306ad8a\", \"locale\": 1, \"title\": \"First Post\", \"draft_title\": \"First Post\", \"slug\": \"first-post\", \"content_type\": 41, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/blog-index/first-post/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"locked_at\": null, \"locked_by\": null, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"alias_of\": null, \"body\": \"[{\\\"type\\\": \\\"paragraph\\\", \\\"value\\\": \\\"<p>Here is some content.</p>\\\", \\\"id\\\": \\\"29da8c6a-0b82-4f0b-b521-02c9c41702db\\\"}]\", \"tagged_items\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "blog.blogpageindex",
+  "pk": 3,
+  "fields": {}
+},
+{
+  "model": "blog.blogpage",
+  "pk": 4,
+  "fields": {
+    "body": "[{\"type\": \"paragraph\", \"value\": \"<p>Here is some content.</p>\", \"id\": \"29da8c6a-0b82-4f0b-b521-02c9c41702db\"}]"
+  }
+}
+]

--- a/blog/models.py
+++ b/blog/models.py
@@ -1,14 +1,17 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.db.models import Q
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.text import slugify
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
+from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page
 from wagtail.search import index
@@ -23,6 +26,7 @@ class Tag(models.Model):
 
     Legacy model from old, pre-wagtail blog
     """
+
     # name indexed because we order on name
     name = models.CharField(max_length=50, unique=True, db_index=True)
     slug = models.SlugField(max_length=50)
@@ -45,6 +49,7 @@ class Post(models.Model):
 
     Legacy model from old, pre-wagtail blog
     """
+
     title = models.CharField(max_length=100)
     content = models.TextField(blank=True)
     created_date = models.DateTimeField(auto_now_add=True)
@@ -52,10 +57,18 @@ class Post(models.Model):
     tags = models.ManyToManyField('blog.Tag', blank=True, related_name='posts')
     is_published = models.BooleanField(db_index=True, default=False, blank=True)
     published_date = models.DateTimeField(db_index=True, null=True, default=None, blank=True)
-    user = models.ForeignKey('accounts.User', null=True, on_delete=models.SET_NULL, default=None, blank=True,
-                             db_index=True, related_name='posts')
-    slug = models.SlugField(help_text='Automatically built from the title.', db_index=True, blank=True, default='',
-                            max_length=100)
+    user = models.ForeignKey(
+        'accounts.User',
+        null=True,
+        on_delete=models.SET_NULL,
+        default=None,
+        blank=True,
+        db_index=True,
+        related_name='posts',
+    )
+    slug = models.SlugField(
+        help_text='Automatically built from the title.', db_index=True, blank=True, default='', max_length=100
+    )
     objects = PublishedPostQuerySet.as_manager()
 
     def get_absolute_url(self):
@@ -82,10 +95,11 @@ class BlogPageTag(TaggedItemBase):
     content_object = ParentalKey('blog.BlogPage', on_delete=models.CASCADE, related_name='tagged_items')
 
 
-class BlogPageIndex(Page):
+class BlogPageIndex(RoutablePageMixin, Page):
     """
     Index page to list blog posts
     """
+
     # For pagination, look here: https://stackoverflow.com/questions/40365500/pagination-in-wagtail
     # and for general: https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/blog/models.py#L133
     template = 'wagtail_templates/blog/post_index.html'
@@ -125,6 +139,28 @@ class BlogPageIndex(Page):
         context['posts'] = page.object_list
         context['page_obj'] = page
         return context
+
+    @route(r'^(?P<id>\d+)/(?P<slug>[-_\w]+)/$', name="blog_post_by_id_and_slug")
+    def blog_post_by_id_and_slug(self, request, id, slug, *args, **kwargs) -> HttpResponse:
+        """
+        Look up post using the a "slug" which is really the post id followed by the actual slug
+        """
+        page = BlogPage.objects.filter(pk=id)
+        if not getattr(request, 'is_preview', False):
+            page = page.live()
+        page = page.first()
+        if not page:
+            raise Http404
+
+        if not page.slug == slug:
+            # using this for efficiency vs page.get_id_and_slug_url()
+            # TODO: review wagtail docs to see if there is a simple and efficient way to have it just default
+            # to the id and slug url for page.url
+            return HttpResponseRedirect(
+                self.url + self.reverse_subpage('blog_post_by_id_and_slug', kwargs={'id': id, 'slug': page.slug})
+            )
+        # or return blog_page.serve(request, *args, **kwargs) ??
+        return page.serve(request, *args, **kwargs)
 
 
 class BlogPage(Page):
@@ -183,21 +219,35 @@ class BlogPage(Page):
         index.SearchField('body'),
         index.SearchField('tags'),
         index.RelatedFields(
-            'owner', (index.SearchField('email'), index.SearchField('first_name'), index.SearchField('last_name')))
+            'owner', (index.SearchField('email'), index.SearchField('first_name'), index.SearchField('last_name'))
+        ),
     ]
 
     def __str__(self):
         return self.title
 
+    @cached_property
+    def id_and_slug_url(self) -> str:
+        # tempted to just put this in actual cache instead, but that feels dirty on a model even though this model
+        # is really more akin to a django view
+        return self.get_id_and_slug_url()
+
     def get_context(self, request):
         context = super().get_context(request)
 
-        # TODO: Is this really going to happen? Same first published but id lower? or higher?
         if self.first_published_at and self.pk:
+            # TODO: Is this really going to happen? Same first published but id lower? or higher?
+            # I think it would work just as well to just make this:
+            # BP.live().filter(first_published_at__lte=self.first_published_at).exclude(pk=self.pk).order_by('-first_published_at', 'id')
             previous_post_q = Q(first_published_at=self.first_published_at, id__lt=self.id)
             previous_post_q = previous_post_q | Q(first_published_at__lt=self.first_published_at)
-            previous_post = BlogPage.objects.live().filter(previous_post_q).exclude(pk=self.pk).order_by(
-                '-first_published_at', 'id').first()
+            previous_post = (
+                BlogPage.objects.live()
+                .filter(previous_post_q)
+                .exclude(pk=self.pk)
+                .order_by('-first_published_at', 'id')
+                .first()
+            )
         else:
             previous_post = BlogPage.objects.live().order_by('-first_published_at', 'id').first()
 
@@ -212,3 +262,15 @@ class BlogPage(Page):
         context['previous_post'] = previous_post
         context['next_post'] = next_post
         return context
+
+    def get_id_and_slug_url(self) -> str:
+        """
+        Returns the url path for post_by_id_and_slug route
+        """
+        # lightly modified from https://github.com/wagtail/wagtail/blob/ba6f94def17b8bbc66002cbc7af60ed422658ff1/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py#L10
+        parent = self.get_parent().specific
+        base_url = parent.relative_url(self.get_site())
+        routed_url = parent.reverse_subpage('blog_post_by_id_and_slug', kwargs={'id': self.pk, 'slug': self.slug})
+        if not base_url.endswith('/'):
+            base_url += '/'
+        return base_url + routed_url

--- a/blog/tests/test_models.py
+++ b/blog/tests/test_models.py
@@ -1,14 +1,21 @@
-from django.test import TestCase
-from django.utils.text import slugify
-from django.urls import reverse
+import unittest
 
-from .factories import PublishedPostFactory
-from .models import Tag
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.text import slugify
+
+from wagtail.core.models import Page
+from wagtail.tests.utils import WagtailPageTests
+
+from ..factories import PublishedPostFactory
+from ..models import Tag, BlogPage, BlogPageIndex
 
 
 class TagTests(TestCase):
     """Test the Tag model"""
 
+    # DEPRECATED
+    @unittest.skip('Model is deprecated and unused')
     def test_save(self):
         """
         Test that save sets slug
@@ -24,6 +31,7 @@ class PostTests(TestCase):
     Test the Post model
     """
 
+    # DEPRECATED
     @classmethod
     def setUpTestData(cls):
         cls.post = PublishedPostFactory()
@@ -31,12 +39,15 @@ class PostTests(TestCase):
     def setUp(self):
         self.post.refresh_from_db()
 
+    @unittest.skip('Model is deprecated and unused')
     def test_str(self):
         self.assertEqual(self.post.title, self.post.__str__())
 
+    @unittest.skip('Model is deprecated and unused')
     def test_get_absolute_url_when_published(self):
         self.assertEqual(self.post.get_absolute_url(), reverse('blog_post_detail', args=[self.post.slug]))
 
+    @unittest.skip('Model is deprecated and unused')
     def test_get_absolute_url_when_not_published(self):
         """
         Unpublished posts should return the preview url
@@ -44,6 +55,7 @@ class PostTests(TestCase):
         self.post.is_published = False
         self.assertEqual(self.post.get_absolute_url(), reverse('blog_post_preview', args=[self.post.slug]))
 
+    @unittest.skip('Model is deprecated and unused')
     def test_save(self):
         """
         Test the overridden save() sets correct slug
@@ -51,3 +63,46 @@ class PostTests(TestCase):
         self.post.slug = ''
         self.post.save()
         self.assertEqual(slugify(self.post.title), self.post.slug)
+
+
+class BlogPageTest(WagtailPageTests):
+    """
+    Tests blog.models.BlogPage
+    """
+
+    fixtures = ['blog/fixtures/test_pages']
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.index_page = BlogPageIndex.objects.live().first()
+        cls.published_blog_page = BlogPage.objects.live().first()
+
+    @unittest.skip('Skipped because I have not written this but at least I will see skipped tests now.')
+    def test_can_create_page(self):
+        """
+        Test creating a BlogPage under the BlogPageIndex via form with expected data creates the page.
+        """
+        index_page = BlogPageIndex.objects.live().first()
+
+    def test_get_id_and_slug_url(self):
+        """
+        Test that BlogPage.
+        """
+        blog_page = BlogPage.objects.live().first()
+        self.assertEqual(f'/blog-index/{blog_page.pk}/{blog_page.slug}/', blog_page.get_id_and_slug_url())
+
+    def test_request_by_id_and_slug_route(self):
+        r = self.client.get(self.published_blog_page.get_id_and_slug_url())
+        self.assertEqual(200, r.status_code)
+
+    def test_request_by_id_and_slug_route_redirects_on_slug_mismatch(self):
+        """
+        Test that a GET request to the id_and_slug_url redirects to the correct slug if the requested slug does not
+        match the current slug.
+        """
+        url = self.published_blog_page.get_id_and_slug_url()
+        url = f'{url[:-1]}1/'
+        r = self.client.get(url)
+        self.assertRedirects(
+            r, self.published_blog_page.get_id_and_slug_url(),
+        )

--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from accounts.factories import UserFactory
-from .factories import PublishedPostFactory, UnpublishedPostFactory
+from ..factories import PublishedPostFactory, UnpublishedPostFactory
 
 # TODO: new tests for testing wagtail Page models.
 

--- a/on_tap/fixtures/test_pages.json
+++ b/on_tap/fixtures/test_pages.json
@@ -3,8 +3,8 @@
   "model": "accounts.user",
   "pk": 1,
   "fields": {
-    "password": "pbkdf2_sha256$180000$AlRq4DFzQbjJ$FOfa6U+/cB5F8A9pVUlwqCqKAuPCqmQx5RDAA6BOjOE=",
-    "last_login": "2020-07-24T21:20:45.783Z",
+    "password": "pbkdf2_sha256$216000$isjq49ApzrdN$8faY+G23K4TB/o3eJsqbSm2EjtiRS9kVc7B83xZxI/8=",
+    "last_login": "2020-12-31T19:01:56.887Z",
     "is_superuser": true,
     "email": "user@example.org",
     "first_name": "",
@@ -18,12 +18,33 @@
   }
 },
 {
+  "model": "sites.site",
+  "pk": 1,
+  "fields": {
+    "domain": "example.com",
+    "name": "example.com"
+  }
+},
+{
+  "model": "wagtailcore.site",
+  "pk": 1,
+  "fields": {
+    "hostname": "localhost",
+    "port": 80,
+    "site_name": "",
+    "root_page": 2,
+    "is_default_site": true
+  }
+},
+{
   "model": "wagtailcore.page",
   "pk": 1,
   "fields": {
     "path": "0001",
     "depth": 1,
     "numchild": 1,
+    "translation_key": "78f32a7f-3264-4d1d-a4af-98123dbc8881",
+    "locale": 1,
     "title": "Root",
     "draft_title": "Root",
     "slug": "root",
@@ -47,7 +68,8 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": null,
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -57,6 +79,8 @@
     "path": "00010001",
     "depth": 2,
     "numchild": 1,
+    "translation_key": "44c8b50c-9006-4877-90a7-bff9f4285ab3",
+    "locale": 1,
     "title": "Welcome to your new Wagtail site!",
     "draft_title": "Welcome to your new Wagtail site!",
     "slug": "home",
@@ -80,7 +104,8 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": null,
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -90,6 +115,8 @@
     "path": "000100010001",
     "depth": 3,
     "numchild": 2,
+    "translation_key": "33fe00e3-4f94-4f66-90c1-c21adcbd53f9",
+    "locale": 1,
     "title": "On Tap",
     "draft_title": "On Tap",
     "slug": "on-tap",
@@ -115,7 +142,8 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": "2020-07-24T21:21:35.141Z",
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -125,6 +153,8 @@
     "path": "0001000100010001",
     "depth": 4,
     "numchild": 1,
+    "translation_key": "e7b8888a-dc80-4b4f-8627-e1d696fb4618",
+    "locale": 1,
     "title": "Recipes",
     "draft_title": "Recipes",
     "slug": "recipes",
@@ -150,7 +180,8 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": "2020-07-24T21:21:59.713Z",
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -159,7 +190,9 @@
   "fields": {
     "path": "0001000100010002",
     "depth": 4,
-    "numchild": 0,
+    "numchild": 1,
+    "translation_key": "753254ac-cd97-43b7-b99c-8e89125eea9e",
+    "locale": 1,
     "title": "Batches",
     "draft_title": "Batches",
     "slug": "batches",
@@ -185,7 +218,8 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": "2020-07-24T21:22:19.213Z",
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -195,6 +229,8 @@
     "path": "00010001000100010001",
     "depth": 5,
     "numchild": 0,
+    "translation_key": "56b08a6c-cf7d-4b76-96e1-68226b85e16a",
+    "locale": 1,
     "title": "Porter",
     "draft_title": "Porter",
     "slug": "porter",
@@ -220,7 +256,46 @@
     "first_published_at": null,
     "last_published_at": null,
     "latest_revision_created_at": "2020-07-25T16:40:45.255Z",
-    "live_revision": null
+    "live_revision": null,
+    "alias_of": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 7,
+  "fields": {
+    "path": "00010001000100020001",
+    "depth": 5,
+    "numchild": 0,
+    "translation_key": "71d7ad39-ab72-4215-a809-c594dc996059",
+    "locale": 1,
+    "title": "Test Porter Batch - Unbrewed",
+    "draft_title": "Test Porter Batch - Unbrewed",
+    "slug": "test-porter-batch-unbrewed",
+    "content_type": [
+      "on_tap",
+      "batchlogpage"
+    ],
+    "live": false,
+    "has_unpublished_changes": true,
+    "url_path": "/home/on-tap/batches/test-porter-batch-unbrewed/",
+    "owner": [
+      "user@example.org"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "locked_at": null,
+    "locked_by": null,
+    "first_published_at": null,
+    "last_published_at": null,
+    "latest_revision_created_at": "2020-12-31T19:03:25.118Z",
+    "live_revision": null,
+    "alias_of": null
   }
 },
 {
@@ -280,6 +355,20 @@
   }
 },
 {
+  "model": "wagtailcore.pagerevision",
+  "pk": 5,
+  "fields": {
+    "page": 7,
+    "submitted_for_moderation": false,
+    "created_at": "2020-12-31T19:03:25.118Z",
+    "user": [
+      "user@example.org"
+    ],
+    "content_json": "{\"pk\": 7, \"path\": \"00010001000100020001\", \"depth\": 5, \"numchild\": 0, \"translation_key\": \"71d7ad39-ab72-4215-a809-c594dc996059\", \"locale\": 1, \"title\": \"Test Porter Batch - Unbrewed\", \"draft_title\": \"Test Porter Batch - Unbrewed\", \"slug\": \"test-porter-batch-unbrewed\", \"content_type\": 53, \"live\": false, \"has_unpublished_changes\": false, \"url_path\": \"/home/on-tap/batches/test-porter-batch-unbrewed/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"locked_at\": null, \"locked_by\": null, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"alias_of\": null, \"recipe_page\": 6, \"status\": \"planned\", \"brewed_date\": null, \"packaged_date\": null, \"on_tap_date\": null, \"off_tap_date\": null, \"original_gravity\": \"1.050\", \"final_gravity\": \"0.00\", \"body\": \"[]\", \"created_at\": \"2020-12-31T19:03:25.092Z\", \"updated_at\": \"2020-12-31T19:03:25.118Z\"}",
+    "approved_go_live_at": null
+  }
+},
+{
   "model": "on_tap.recipehop",
   "pk": 1,
   "fields": {
@@ -308,6 +397,7 @@
     "amount_units": "lb",
     "notes": "",
     "name": "Crisp Marris Otter",
+    "maltster": "",
     "type": "grain",
     "color": "3.000",
     "created_at": "2020-07-25T16:40:45.227Z",
@@ -324,6 +414,7 @@
     "amount_units": "oz",
     "notes": "",
     "name": "Crisp Brown Malt",
+    "maltster": "",
     "type": "grain",
     "color": "85.000",
     "created_at": "2020-07-25T16:40:45.228Z",
@@ -340,6 +431,7 @@
     "amount_units": "oz",
     "notes": "",
     "name": "Briess Caramel 40",
+    "maltster": "",
     "type": "grain",
     "color": "40.000",
     "created_at": "2020-07-25T16:40:45.229Z",
@@ -356,6 +448,7 @@
     "amount_units": "oz",
     "notes": "",
     "name": "Briess Caramel 80",
+    "maltster": "",
     "type": "grain",
     "color": "80.000",
     "created_at": "2020-07-25T16:40:45.229Z",
@@ -372,6 +465,7 @@
     "amount_units": "oz",
     "notes": "",
     "name": "Crisp Chocolate",
+    "maltster": "",
     "type": "grain",
     "color": "450.000",
     "created_at": "2020-07-25T16:40:45.230Z",
@@ -388,6 +482,7 @@
     "amount_units": "oz",
     "notes": "",
     "name": "Crisp Pale Chocolate",
+    "maltster": "",
     "type": "grain",
     "color": "225.000",
     "created_at": "2020-07-25T16:40:45.230Z",
@@ -433,6 +528,7 @@
     "carbonation_min": null,
     "carbonation_max": null,
     "notes": "",
+    "external_url": "",
     "created_at": "2020-07-25T16:25:01.066Z",
     "updated_at": "2020-07-25T16:25:01.066Z"
   }
@@ -461,6 +557,23 @@
     "conclusion": "[{\"type\": \"paragraph\", \"value\": \"<p>And now after making that, you have beer.</p>\", \"id\": \"c578ceff-a2b2-4ed2-9744-23b67c9dec4a\"}]",
     "created_at": "2020-07-25T16:40:45.218Z",
     "updated_at": "2020-07-25T16:40:45.218Z"
+  }
+},
+{
+  "model": "on_tap.batchlogpage",
+  "pk": 7,
+  "fields": {
+    "recipe_page": 6,
+    "status": "planned",
+    "brewed_date": null,
+    "packaged_date": null,
+    "on_tap_date": null,
+    "off_tap_date": null,
+    "original_gravity": "1.050",
+    "final_gravity": "0.000",
+    "body": "[]",
+    "created_at": "2020-12-31T19:03:25.092Z",
+    "updated_at": "2020-12-31T19:03:25.092Z"
   }
 },
 {


### PR DESCRIPTION
* BlogPage url routes with id and slug
* on tap RrecipePage and BatchLogPage urls with page ids
* Test cases for the id_and_slug_url routes and model methods to test
normal function and correct redirect when id matches but not slug.
* Made cached_property to use over get_id_and_slug_url