### PR TITLE
Begin removing markdown from open_source.html template

### DIFF
--- a/bash_shell_net/templates/about.html
+++ b/bash_shell_net/templates/about.html
@@ -10,9 +10,9 @@
     <h2>About</h2>
   </div>
   <hr />
-{% markdown %}
-This site started as my first Django project, more or less following along with a tutorial that walked through
-creating a super simple blogging site.  While it still acts as my blog, it is also a testbed for trying
-new ways of organizing Django, new apps, and new ways to handle hosting and deployment.
-{% endmarkdown %}
+  <p>
+    This site started as my first Django project, more or less following along with a tutorial that walked through
+    creating a super simple blogging site. While it still acts as my blog, it is also a testbed for trying
+    new ways of organizing Django, new apps, and new ways to handle hosting and deployment.
+  </p>
 {% endblock %}

--- a/bash_shell_net/templates/open_source.html
+++ b/bash_shell_net/templates/open_source.html
@@ -10,103 +10,117 @@
     <h2>Open Source</h2>
   </div>
   <div class="blog-post col-12">
-{% markdown %}
-## Why Open Source?
+    <h2>Why Open Source?</h2>
+    <p>
+      Open Source Software has been a major part of my daily life since the mid-90s.  Years before I was familiar with the term Open Source I was running Slackware Linux 2.0, compiling horribly written code with gcc, and hosting toy websites no one visited using Apache on a dialup internet connection (which of course were only available when I was online and had given someone my ip address for that session).  Those free, professional, production quality tools gave me a head start on learning and helped keep my interest long enough to turn it all into a career where I am paid well to do more or less what I'd be doing with much of my free time (and still do with a lot of it) anyway.
+    </p>
+    <p>
+      Because of what Open Source has done for me (and for many others) I have a strong desire to contribute back and to encourage others to do so.  I have all too infrequently contributed bug fixes and features to projects I use regularly and thanks to my employer [Mobelux](https://mobelux.com/) and our client/partner [Livio](https://livio.io/) I have been able to release a few projects from work.  I have also released a few of my own projects which others may find useful, although they are still mostly toys for me to learn and I have little desire to have to grow a community of contributors around them.
+    </p>
+    <p>A more complete blog post about Open Source and its benefits will be coming in the near future.</p>
 
-Open Source Software has been a major part of my daily life since the mid-90s.  Years before I was familiar with the term Open Source I was running Slackware Linux 2.0, compiling horribly written code with gcc, and hosting toy websites no one visited using Apache on a dialup internet connection (which of course were only available when I was online and had given someone my ip address for that session).  Those free, professional, production quality tools gave me a head start on learning and helped keep my interest long enough to turn it all into a career where I am paid well to do more or less what I'd be doing with much of my free time (and still do with a lot of it) anyway.
-
-Because of what Open Source has done for me (and for many others) I have a strong desire to contribute back and to encourage others to do so.  I have all too infrequently contributed bug fixes and features to projects I use regularly and thanks to my employer [Mobelux](https://mobelux.com/) and our client/partner [Livio](https://livio.io/) I have been able to release a few projects from work.  I have also released a few of my own projects which others may find useful, although they are still mostly toys for me to learn and I have little desire to have to grow a community of contributors around them.
-
-A more complete blog post about Open Source and its benefits will be coming in the near future.
-
-## Contributions
-
-### My Projects
-
-Here are some of my more recent and/or interesting and active Open Source projects.  There are many more on [my github profile](https://github.com/jmichalicek), but many of those are old, abandoned, etc.
-<div  class="row ml-0 mr-0">
-<div class="col-sm-4 card" markdown="1">
-### django-mailviewer
-[Docs](https://django-mail-viewer.readthedocs.io/en/latest/) | [github](https://github.com/jmichalicek/django-mail-viewer)
-
-A Django application which provides mail backends to store SMTP data and views to look that data up and display it for easy visual testing of email content and attachments during development.
-</div>
-<div class="col-sm-4 card" markdown="1">
-### django-fractions
-[Docs](https://django-fractions.readthedocs.io/en/latest/) | [github](https://github.com/jmichalicek/django-fractions)
-
-A set of template tags and form fields for handling and displaying fractions on a Django website
-</div>
-<div class="col-sm-4  card" markdown="1">
-### WorryWort
-[Server github](https://github.com/jmichalicek/worrywort) | [Client github](https://github.com/jmichalicek/worrywort-client-react-native)
-
-A Phoenix/Elixir project for logging homebrew fermentation temperatures and a React Native mobile app.  These are both a work in progress and are nowhere near ready for use.  Eventually I will also add code for monitoring and reporting temperatures from a Raspberry Pi and possibly Arduino.
-</div>
-</div>
-
------
-
-### Other Projects
-<div class="row ml-0 mr-0">
-<div class="col-sm-4  card" markdown="1">
-### [Django](https://djangoproject.com)
-[Contributions](https://github.com/django/django/commits?author=jmichalicek)
-
-One of the big Python web frameworks.  It runs this site, many of the sites we build at Mobelux, and many popular sites on the web such as [Instagram](https://instagram.com/), [Pinterest](https://pinterest.com/) (initially, at any rate), and [Disqus](https://disqus.com).
-</div>
-<div class="col-sm-4  card">
-### [Django AllAuth](https://www.intenct.nl/projects/django-allauth/)
-
-[Contributions](https://github.com/pennersr/django-allauth/commits?author=jmichalicek)
-
-Django AllAuth is an alternative authentication framework for Django.  Django's built in auth system only covers authentication and password reset type functionality.  Django AllAuth adds in things like social auth and user registration.
-</div>
-<div class="col-sm-4  card" markdown="1">
-### [Docker-py](https://github.com/docker/docker-py/)
-
-[Contributions](https://github.com/docker/docker-py/commits?author=jmichalicek)
-
-It's the Python [Docker](https://www.docker.com/docker-community) client.
-</div>
-</div>
-<div class="row ml-0 mr-0">
-<div class="col-sm-4  card" markdown="1">
-### [DocDown-Python](https://github.com/livio/DocDown-Python)
-
-This was developed  by my employer, [Mobelux](https://mobelux.com/) for [Livio](https://livio.io) and the [SmartDeviceLink](https://smartdevicelink.com) project.  Livio chose to open source the project.  I get an unfair amount of credit in the commits on this one.  The majority was developed by a [co-worker](https://github.com/jemerick), but I got to extract it out of the original project into its own package.
-</div>
-<div class="col-sm-4 card" markdown="1">
-### [Remarkable DocDown](https://github.com/livio/DocDown-JS)
-
-This is the JavaScript version of DocDown for use with the JavaScript Markdown library Remarkable.
-</div>
-<div class="col-sm-4  card" markdown="1">
-### [JWT APNS Client](https://github.com/Mobelux/jwt_apns_client)
-
-[Contributions](https://github.com/Mobelux/jwt_apns_client/commits?author=jmichalicek)
-
-JWT APNS Client was built at [Mobelux](https://mobelux.com/) for [New Custom](https://newcustom.com/).  Mobelux and New Custom were under the same ownership and it was chosen to be open sourced for ease of use in other Mobelux projects which needed to send Apple push notifications.
-</div>
-</div>
-
------
-
-## Find ways to contribute
-
-Here are a few of my favorites with a large and interesting community around them.
-
-* [Django Channels](https://channels.readthedocs.io/en/stable/contributing.html)
-* [Django](https://docs.djangoproject.com/en/dev/internals/contributing/)
-* [Ruby On Rails](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html)
-* [Phoenix](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md)
-* [Let's Encrypt](https://letsencrypt.org/getinvolved/)
-
-Here are some resources for just finding projects to contribute to
-
-* [Code Triage](https://www.codetriage.com/)
-* [Explore GitHub](https://help.github.com/articles/finding-open-source-projects-on-github/)
-* [Up For Grabs](http://up-for-grabs.net/#/)
-{% endmarkdown %}
-</div>
+    <h2>Contributions</h2>
+    <h3>My Projects</h3>
+    <p>
+      Here are some of my more recent and/or interesting and active Open Source projects.  There are many more on <a href="https://github.com/jmichalicek">my github profile</a>,
+      but many of those are old, abandoned, etc.
+    </p>
+    <div class="row ml-0 mr-0">
+      <div class="col-sm-4 card">
+        <h3>django-mailviewer</h3>
+        <p><a href="https://django-mail-viewer.readthedocs.io/en/latest/">Docs</a> | <a href="https://github.com/jmichalicek/django-mail-viewer">github</a></p>
+        <p>
+          A Django application which provides mail backends to store SMTP data and views to look that data up and display it for easy visual testing of email content and attachments during development.
+        </p>
+      </div>
+      <div class="col-sm-4 card">
+        <h3>django-fractions</h3>
+        <p><a href="https://django-fractions.readthedocs.io/en/latest/">Docs</a> | <a href="https://github.com/jmichalicek/django-fractions">github</a></p>
+        <p>A set of template tags and form fields for handling and displaying fractions on a Django website</p>
+      </div>
+      <div class="col-sm-4 card">
+        <h3>WorryWort</h3>
+        <p><a href="https://github.com/jmichalicek/worrywort-server-go">Go Server</a></p>
+        <p>
+          A system for logging homebrew fermentation temperatures. It has been used an experiment for learning
+          different programming languages and frameworks. Its current codebase is a Go web service
+          and a Xamarin.Forms client. The client is not currently open source due to the licenses of a few libraries
+          which I hope to replace. This was originally a <a href="https://github.com/jmichalicek/worrywort">Phoenix/Elixir server</a>
+          and a <a href="https://github.com/jmichalicek/worrywort-client-react-native">React Native mobile app</a>. After
+          a long break due to a second child being born and changes in my language interests, that version was abandoned to start the current codebase.
+          Eventually I will also add code for monitoring and reporting temperatures from a
+          Raspberry Pi and possibly Arduino.
+        </p>
+      </div>
+    </div>
+    <hr />
+    <h3>Other Projects</h3>
+    <div class="row ml-0 mr-0">
+      <div class="col-sm-4 card">
+        <h3><a href="https://djangoproject.com">Django</a></h3>
+        <p>
+          <a href="https://github.com/django/django/commits?author=jmichalicek">Contributions</a>
+        </p>
+        <p>
+          One of the big Python web frameworks.  It runs this site, many of the sites we build at Mobelux, and many popular
+          sites on the web such as <a href="https://instagram.com/">Instagram</a>, <a href="https://mozilla.org/">Mozilla</a>, and <a href="https://disqus.com">Disqus</a>.
+        </p>
+      </div>
+      <div class="col-sm-4 card">
+        <h3><a href="https://www.intenct.nl/projects/django-allauth/">Django AllAuth</a></h3>
+        <p><a href="https://github.com/pennersr/django-allauth/commits?author=jmichalicek">Contributions</a></p>
+        <p>
+          Django AllAuth is an alternative authentication framework for Django. Django's built in auth system only covers
+          authentication and password reset type functionality. Django AllAuth adds in things like social auth and user registration.
+        </p>
+      </div>
+      <div class="col-sm-4 card">
+          <h3><a href="https://github.com/docker/docker-py/">Docker-py</a></h3>
+          <p><a href="https://github.com/docker/docker-py/commits?author=jmichalicek">Contributions</a></p>
+          <p>It's the (now old version of the) Python <a href="https://www.docker.com/docker-community">Docker</a> client.</a>
+      </div>
+    </div>
+    <div class="row ml-0 mr-0">
+      <div class="col-sm-4 card">
+        <h3><a href="https://github.com/livio/DocDown-Python">DocDown-Python</a></h3>
+        <p>
+          This was developed by my employer, <a href="https://mobelux.com">Mobelux</a> for <a href="https://livio.io">Livio</a>
+          and the <a href="https://smartdevicelink.com">SmartDeviceLink</a> project. Livio chose to open source the
+          project. I get an unfair amount of credit in the commits on this one. The majority was developed by a
+          <a href="https://github.com/jemeric">a co-worker</a>, but I got to extract it out of the original project into
+          its own package.
+        </p>
+      </div>
+      <div class="col-sm-4 card">
+        <h3><a href="https://github.com/livio/DocDown-JS">Remarkable DocDown</a></h3>
+        <p>This is the JavaScript version of DocDown for use with the JavaScript Markdown library Remarkable.</p>
+      </div>
+      <div class="col-sm-4 card">
+        <h3><a href="https://github.com/Mobelux/jwt_apns_client">JWT APNS Client</a></h3>
+        <p><a href="https://github.com/Mobelux/jwt_apns_client/commits?author=jmichalicek">Contributions</a></p>
+        <p>
+          JWT APNS Client was built at <a href="https://mobelux.com">Mobelux</a> for the now defunct New Custom project.
+          Mobelux and New Custom were under the same ownership and it was chosen to be open sourced for ease of use in
+          other Mobelux projects which needed to send Apple push notifications at a time when there were no other clients
+          using their newer protocol.
+        </p>
+      </div>
+    </div>
+    <hr />
+    <h2>Find ways to contribute</h2>
+    <p>Here are a few of my favorites with a large and interesting community around them.</p>
+    <ul>
+      <li><a href="https://docs.djangoproject.com/en/dev/internals/contributing/">Django</a></li>
+      <li><a href="https://channels.readthedocs.io/en/stable/contributing.html">Django Channels</a></li>
+      <li><a href="http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html">Ruby On Rails</a></li>
+      <li><a href="https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md">Phoenix</a></li>
+      <li><a href="https://letsencrypt.org/getinvolved/">Let's Encrypt</a></li>
+    </ul>
+    <p>Here are some resources for just finding projects to contribute to</p>
+    <ul>
+      <li><a href="https://www.codetriage.com/">Code Triage</a></li>
+      <li><a href="https://help.github.com/articles/finding-open-source-projects-on-github/">Explore GitHub</a></li>
+      <li><a href="http://up-for-grabs.net/#/">Up For Grabs</a></li>
+    </ul>
+  </div>
 {% endblock %}


### PR DESCRIPTION
* Something has broken with rendering markdown nested inside html from the markdown.extras package.
  Since this was always considered a bit quirky behavior and not how markdown was intended to work
  all markdown is being removed and plain old html written.